### PR TITLE
Updated connection.rb for vCloud Air

### DIFF
--- a/lib/ruby_vcloud_sdk/connection/connection.rb
+++ b/lib/ruby_vcloud_sdk/connection/connection.rb
@@ -31,9 +31,9 @@ module VCloudSdk
 
       def connect(username, password)
         login_password = "#{username}:#{password}"
-        auth_header_value = "Basic #{Base64.encode64(login_password)}"
-        response = @site[login_url].post(
-            Authorization: auth_header_value, Accept: ACCEPT)
+        auth_header_value = "Basic #{Base64.strict_encode64(login_password)}"
+        response = @site[login_url].post(nil,
+            {Authorization: auth_header_value, Accept: ACCEPT})
         Config.logger.debug(response)
         @cookies = response.cookies
         unless @cookies["vcloud-token"].gsub!("+", "%2B").nil?


### PR DESCRIPTION
The strict_encode64 is being used instead of encode64 since "\n" was present based on longer usernames, ie. "clintonskitson@email.com@guid-asdsaasd-asdasdasdas.  I believe it is 60 characters that encode64 starts adding line breaks.

The post also had to be modified since headers were being added to the authorization parameter.
